### PR TITLE
Connect top holder list to Solscan API

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,14 @@
     .address-link {
       text-decoration: none;
       color: #007bff;
+      font-size: 14px;
+      word-break: break-all;
+    }
+    #holders-list, #holders-list-mobile {
+      padding-left: 20px;
+      list-style: none;
+      margin: 0;
+      word-break: break-word;
     }
     .ratio-bar {
       height: 20px;
@@ -308,6 +316,7 @@
 </footer>
 <script>
     let tokenInterval;
+    let holdersInterval;
 
     function handleKeyPress(e) {
       if (e.key === "Enter") searchToken();
@@ -315,6 +324,28 @@
 
     function isValidSolanaAddress(addr) {
       return /^([1-9A-HJ-NP-Za-km-z]{32,44})$/.test(addr);
+    }
+
+    function fetchTopHolders(ca, apiKey, listId = 'holders-list') {
+      const list = document.getElementById(listId);
+      if (!list) return;
+      list.innerHTML = '<li>Loading...</li>';
+      const url = `https://pro-api.solscan.io/v2.0/token/holders?address=${ca}&page=1&page_size=10`;
+      fetch(url, { headers: { token: apiKey } })
+        .then(r => r.json())
+        .then(data => {
+          if (!data || !data.data) throw new Error('holder fail');
+          list.innerHTML = data.data.items.slice(0, 10).map(it => {
+            const addr = it.owner;
+            const pct = Number(it.percentage || 0);
+            const short = `${addr.slice(0,4)}...${addr.slice(-4)}`;
+            return `<li><a class="address-link" href="https://solscan.io/account/${addr}" target="_blank">${short}</a> - ${pct.toFixed(1)}%</li>`;
+          }).join('');
+        })
+        .catch(err => {
+          console.error(err);
+          list.innerHTML = '<li>Error loading holders</li>';
+        });
     }
 
     function searchToken() {
@@ -370,6 +401,9 @@
 
 
           resultSection.style.display = "block";
+          if (holdersInterval) clearInterval(holdersInterval);
+          fetchTopHolders(ca, solscanKey);
+          holdersInterval = setInterval(() => fetchTopHolders(ca, solscanKey), 10000);
 
           const widgetContainer = document.getElementById(
             "price-chart-widget-container"
@@ -459,8 +493,8 @@
 </div></div><div class="info-grid"><div class="top-holders info-card">
 <h3>Top Holders</h3>
 <ul id="holders-list">
-<!-- Placeholder for holder list -->
-<li><a class="address-link" href="https://solscan.io/account/holder1" target="_blank">3h4f...a9eF</a> - 12.3%</li><li><a class="address-link" href="https://solscan.io/account/holder2" target="_blank">9vFx...Bc42</a> - 9.8%</li><li><a class="address-link" href="https://solscan.io/account/holder3" target="_blank">A1cE...Fd9A</a> - 7.5%</li><li><a class="address-link" href="https://solscan.io/account/holder4" target="_blank">Z8wQ...xXxX</a> - 6.1%</li><li><a class="address-link" href="https://solscan.io/account/holder5" target="_blank">L2rF...wXc3</a> - 5.0%</li><li><a class="address-link" href="https://solscan.io/account/holder6" target="_blank">M0sT...EzQa</a> - 4.4%</li><li><a class="address-link" href="https://solscan.io/account/holder7" target="_blank">HyTr...Yu1R</a> - 3.8%</li><li><a class="address-link" href="https://solscan.io/account/holder8" target="_blank">V1bz...O9Fq</a> - 3.3%</li><li><a class="address-link" href="https://solscan.io/account/holder9" target="_blank">K8bq...TtTx</a> - 2.9%</li><li><a class="address-link" href="https://solscan.io/account/holder10" target="_blank">R4Gh...cVcC</a> - 2.5%</li></ul>
+  <li>Loading...</li>
+</ul>
 </div><div class="holder-change info-card">
 <h3>Holder Change</h3>
 <div id="holder-change-result"><div class="holder-change-grid"><div class="change-card"><div class="label">5m</div><div class="value live-value">+2</div></div><div class="change-card"><div class="label">1h</div><div class="value live-value">+15</div></div><div class="change-card"><div class="label">6h</div><div class="value live-value">+32</div></div><div class="change-card"><div class="label">24h</div><div class="value live-value">+80</div></div><div class="change-card"><div class="label">3d</div><div class="value live-value">+210</div></div><div class="change-card"><div class="label">7d</div><div class="value live-value">+550</div></div><div class="change-card"><div class="label">30d</div><div class="value live-value">+1.4k</div></div></div></div>
@@ -509,10 +543,8 @@
 </div>
 <div style="margin-top:20px;">
 <h3 style="font-size:16px; border-left:4px solid #61c5ff; padding-left:8px;">Top Holders</h3>
-<ul style="font-size:14px;">
-<li>3h4f...a9eF - 12.3%</li>
-<li>9vFx...Bc42 - 9.8%</li>
-<li>... (8 more)</li>
+<ul id="holders-list-mobile" style="font-size:14px;">
+  <li>Loading...</li>
 </ul>
 </div>
 <div style="margin-top:20px;">
@@ -604,6 +636,9 @@
               `💰 Market Cap: ${marketCap} <br/> 🧪 Liquidity: ${liquidity} <br/> 💠 Supply: ${supply}`;
 
           resultSection.style.display = 'block';
+          if (holdersInterval) clearInterval(holdersInterval);
+          fetchTopHolders(ca, solscanKey, 'holders-list-mobile');
+          holdersInterval = setInterval(() => fetchTopHolders(ca, solscanKey, 'holders-list-mobile'), 10000);
         })
         .catch((err) => {
           console.error(err);


### PR DESCRIPTION
## Summary
- fetch top token holders from Solscan API
- show holder list on both desktop and mobile
- auto refresh every 10 seconds
- apply mobile-friendly styling for holder list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f679a52bc832b8537080cef7e0d3e