### PR TITLE
Adjust layout for fresh wallet ratio

### DIFF
--- a/index_noliquidity_final_updated.html
+++ b/index_noliquidity_final_updated.html
@@ -597,7 +597,7 @@ function updateTopHolders(holders) {
 </div><div class="recent-tx info-card">
 <h3>Recent Buys / Sells</h3>
 <ul id="recent-swaps-list"></ul>
-</div></div><div id="fresh-wallet-ratio" class="info-card" style="margin-top: 20px;">
+</div><div id="fresh-wallet-ratio" class="info-card">
   <h3>📊 Fresh Wallet Ratio</h3>
   <p id="fresh-wallet-count">🟢 Fresh Wallets: 0 / 30</p>
   <p id="fresh-wallet-percentage">📈 Ratio: 0%</p>


### PR DESCRIPTION
## Summary
- move **Fresh Wallet Ratio** card into the info grid beside Recent Buys / Sells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fd9abc04c832b96b47e1b8e83be5c